### PR TITLE
feature/ziggeo-video-recorder: LR-137. Create a separate page for video recorder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
+gem 'angularjs-rails'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'coffee-rails',   '4.1.0'
-gem 'angularjs-rails'
 gem 'coveralls', require: false
 gem 'devise'
 gem 'figaro'
@@ -15,6 +15,7 @@ gem 'sdoc',           '0.4.0', group: :doc
 gem 'turbolinks',     '2.3.0'
 gem 'uglifier',       '2.5.3'
 gem 'will_paginate', '~> 3.0.6'
+gem 'Ziggeo'
 
 group :development, :test do
   gem 'byebug',      '3.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ziggeo (1.06)
+      httmultiparty
+      httparty (~> 0.13.5)
     actionmailer (4.2.2)
       actionpack (= 4.2.2)
       actionview (= 4.2.2)
@@ -86,6 +89,13 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.3)
+    httmultiparty (0.3.16)
+      httparty (>= 0.7.3)
+      mimemagic
+      multipart-post
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jasmine (2.4.0)
       jasmine-core (~> 2.4)
@@ -109,6 +119,7 @@ GEM
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0221)
+    mimemagic (0.3.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
@@ -187,7 +198,7 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    sass (3.4.21)
+    sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -238,6 +249,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  Ziggeo
   angularjs-rails
   bootstrap-sass (~> 3.3.6)
   byebug (= 3.4.0)

--- a/app/assets/javascripts/video_recorder.js
+++ b/app/assets/javascripts/video_recorder.js
@@ -1,0 +1,20 @@
+var ready;
+ready = function() {
+
+  $("#reload-page.btn.btn-primary").click(function() {
+    window.location.reload();
+  });
+
+  return ZiggeoApi.Events.on("submitted", function(data) {
+    var massage, videoStatus;
+    massage = "The video with token " +
+      data.video.token +
+      " has been submitted!";
+    videoStatus = $("#video-status");
+    videoStatus.append(massage);
+    videoStatus.show();
+  });
+};
+
+$(document).ready(ready);
+$(document).on("page:load", ready);

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,2 +1,3 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "video_recorder";

--- a/app/assets/stylesheets/video_recorder.scss
+++ b/app/assets/stylesheets/video_recorder.scss
@@ -1,0 +1,3 @@
+.alert.alert-success {
+  display: none;
+}

--- a/app/controllers/video_recorder_controller.rb
+++ b/app/controllers/video_recorder_controller.rb
@@ -1,0 +1,19 @@
+class VideoRecorderController < ApplicationController
+  before_action :ziggeo_init, :all_videos, only: :index
+
+  def index
+  end
+
+  private
+
+  def ziggeo_init
+    @ziggeo = Ziggeo.new(Rails.application.secrets.ziggeo_api_token,
+                         Rails.application.secrets.ziggeo_private_key,
+                         Rails.application.secrets.ziggeo_encryption_key)
+  end
+
+  def all_videos
+    @all_videos = []
+    @ziggeo.videos.index.map { |video| @all_videos.push(video["token"]) }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,12 +1,17 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>VideoQuiz</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-  <%= csrf_meta_tags %>
-</head>
+  <head>
+    <title>VideoQuiz</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+    <link rel="stylesheet" href="//assets-cdn.ziggeo.com/v1-stable/ziggeo.css"/>
+    <script src="//assets-cdn.ziggeo.com/v1-stable/ziggeo.js"></script>
+    <script>
+      ZiggeoApi.token = "<%= Rails.application.secrets.ziggeo_api_token %>";
+    </script>
+    <%= csrf_meta_tags %>
+  </head>
   <body>
     <%= yield %>
   </body>

--- a/app/views/video_recorder/index.html.erb
+++ b/app/views/video_recorder/index.html.erb
@@ -1,0 +1,66 @@
+</br>
+
+<div class="container-fluid">
+<div class="row">
+  <div class="col-xs-8 col-xs-offset-2">
+    <div class="jumbotron">
+      <h1>Are you ready to ROCK?!</h1>
+      <p>Start to record your video answers IMMEDIATELY, because it's just so easy, save your time for typing some text - BE A PART OF US!</p>
+      <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#videoRecorderModal">
+        Record Video
+      </button>
+    </div><!-- jumbotron -->
+  </div><!-- col-xs-8 col-xs-offset-2 -->
+</div><!-- row -->
+</div><!-- container-fluid -->
+
+<div class="container-fluid">
+<div class="row">
+  <div class="col-xs-8 col-xs-offset-2">
+    <% @all_videos.each_slice(3) do |row_chunk| %>
+    <div class="row">
+      <% row_chunk.each do |video_token| %>
+      <div class="col-xs-4">
+        <ziggeo ziggeo-video="<%= video_token %>" ziggeo-width=320 ziggeo-height=240></ziggeo>
+      </div><!-- col-xs-4 -->
+      <% end %>
+    </div><!-- row -->
+  </br>
+  <% end %>
+</div><!-- col-xs-8 col-xs-offset-2 -->
+</div><!-- row -->
+</div><!-- container-fluid -->
+
+<div class="modal fade" id="videoRecorderModal" tabindex="-1" role="dialog" aria-labelledby="videoRecorderModalLabel">
+<div class="modal-dialog" role="document">
+<div class="modal-content">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title" id="videoRecorderModalLabel">Video recorder</h4>
+  </div><!-- modal-header -->
+  <div class="modal-body">
+    <div class="row">
+      <div class="col-xs-10 col-xs-offset-1">
+        <div id='video-status' class="alert alert-success" role="alert">
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-6 col-xs-offset-3">
+        <div class="wall-of-videos-container">
+          <ziggeo ziggeo-limit=15 ziggeo-width=320 ziggeo-height=240></ziggeo>
+        </div>
+      </div>
+    </div>
+  </div><!-- modal-body -->
+  <div class="modal-footer">
+    <button type="button" id="reload-page" class="btn btn-primary" data-dismiss="modal">Close resorder</button>
+  </div><!-- modal-footer -->
+</div><!-- modal-content -->
+</div><!-- modal-dialog -->
+</div><!-- modal fade -->

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,7 +1,11 @@
-development:
+defaults: &defaults
   SECRET_KEY_BASE:
   FACEBOOK_APP_ID:
   FACEBOOK_APP_SECRET:
   ZIGGEO_API_TOKEN:
   ZIGGEO_PRIVATE_KEY:
   ZIGGEO_ENCRYPTION_KEY:
+
+development: *defaults
+
+test: *defaults

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
+  get "video_recorder", to: "video_recorder#index"
   resources :quizzes
-  get "home/index"
-  devise_for :users, skip: [:password, :sessions],
-              controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
 
+  devise_for :users, skip: [:password, :sessions],
+                     controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   devise_scope :user do
     delete "sign_out", to: "devise/sessions#destroy", as: :destroy_user_session
   end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,20 +10,18 @@
 
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
-
-development:
+defaults: &defaults
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   facebook_app_id: <%= ENV["FACEBOOK_APP_ID"] %>
   facebook_app_secret: <%= ENV["FACEBOOK_APP_SECRET"] %>
+  ziggeo_api_token: <%= ENV["ZIGGEO_API_TOKEN"] %>
+  ziggeo_private_key: <%= ENV["ZIGGEO_PRIVATE_KEY"] %>
+  ziggeo_encryption_key: <%= ENV["ZIGGEO_ENCRYPTION_KEY"] %>
 
-test:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  facebook_app_id: <%= ENV["FACEBOOK_APP_ID"] %>
-  facebook_app_secret: <%= ENV["FACEBOOK_APP_SECRET"] %>
+development: *defaults
+
+test: *defaults
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
-production:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-  facebook_app_id: <%= ENV["FACEBOOK_APP_ID"] %>
-  facebook_app_secret: <%= ENV["FACEBOOK_APP_SECRET"] %>
+production: *defaults

--- a/spec/controllers/video_recorder_controller_spec.rb
+++ b/spec/controllers/video_recorder_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe VideoRecorderController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/video_recorder/index.html.erb_spec.rb
+++ b/spec/views/video_recorder/index.html.erb_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe "video_recorder/index.html.erb", type: :view do
+end

--- a/test/controllers/video_recorder_controller_test.rb
+++ b/test/controllers/video_recorder_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+class VideoRecorderControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### **WAITING UNTIL #33 WOULD BE MERGED TO PASS CODESHIP TEST**
**Prestory:**
Ця гілка вже була змерджена в 1st demo day, проте .yml так і не запрацювали на продакшені (дякую, за аплодисменти), попередній pull request #15

**Reminder:**
Якщо біля вашого нікнейму є checkbox - !!!ВІТАЮ!!! хоч десь Random.org вказав саме на Вас (=
Будь ласка, перегляньте код, лишіть коментарі, якщо ж зауважень немає - поставте галочку, що все ок.

**Update:**
З усіх змін в порівнянні із попереднім pull request:
- перехід на figaro
- переписаний скріпт з .coffee на .js

**JIRA**
**LR-137 Create a separate page and integrate recorder there:** https://ssu-jira.softserveinc.com/browse/LR-137

- [x] @vovka

> 1) @anatoliiibrahimov
> 2) @AntonMayer
> 3) @brouhaha88

- [x] @OKrain
- [x] @sergiy17

> @LaViki 

History:
> rails g controller video-recorder index
> changed view of video_recorder page
> added Ziggeo modal window recorder to vide_recorder page
> plased all videos playback (players for all recorded videos) on a page
> added success callback (show video token if video status successed) from video recorder througth JS
> rewrote video_recorder_controller with strong parameters
> important tokens (like ziggeo or fb) in separate secrets.yml.ci and secrets.yml files
> all .coffee to .js scripts